### PR TITLE
fix: use resolvedTheme for accurate theme handling

### DIFF
--- a/components/mode-toggle.tsx
+++ b/components/mode-toggle.tsx
@@ -1,26 +1,26 @@
-"use client"
+"use client";
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/registry/alpine/ui/button"
-import { Moon, Sun } from "lucide-react"
-import { useTheme } from "next-themes"
+import { cn } from "@/lib/utils";
+import { Button } from "@/registry/alpine/ui/button";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
 
 export function ModeToggle({
   className,
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { theme, setTheme } = useTheme()
+  const { resolvedTheme, setTheme } = useTheme();
 
   return (
     <Button
       variant="secondary"
       size="icon"
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
       className={cn("size-8", className)}
       {...props}
     >
       <Sun className="rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
       <Moon className="absolute rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
     </Button>
-  )
+  );
 }


### PR DESCRIPTION
Implementation similar to [shadcn ui](https://ui.shadcn.com):
https://github.com/shadcn-ui/ui/blob/12d4cf2ab0caefec5d6232e6c32220a8e62d73c4/apps/v4/components/mode-toggle.tsx#L10-L14

This is done because the theme parameter returns `system` instead of `light` or `dark`. This causes an issue where new users (those without a saved theme preference in localStorage) cannot change the theme on their first click. To reproduce the issue, clear cookies and try toggling the theme.

As stated in the [next-themes docs](https://github.com/pacocoursey/next-themes?tab=readme-ov-file#usetheme-1), 
when `enableSystem` is `true` and the active theme is `system`, theme remains `system` while resolvedTheme returns whether the system preference is resolved to `dark` or `light`.